### PR TITLE
Constrain the libs to posix

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,5 +8,5 @@
   "license": "Boost Software License, Version 1.0",
   "homepage": "https://github.com/repeatedly/zstd-d",
   "targetType": "sourceLibrary",
-  "libs": ["zstd"]
+  "libs-posix": ["zstd"]
 }


### PR DESCRIPTION
This library does not apply to Windows and requires difficult workarounds to use it be able to use it on Windows. This way Windows users can specify their own library builds.