### PR TITLE
Fix usage of the deprecated `body` keyword

### DIFF
--- a/source/zstd/compress.d
+++ b/source/zstd/compress.d
@@ -50,7 +50,7 @@ class Compressor
     {
         assert(Level.min <= level && level <= Level.max);
     }
-    body
+    do
     {
         cstream = ZSTD_createCStream();
         buffer = new ubyte[](recommendedOutSize);


### PR DESCRIPTION
Fix this warning:
```
zstd-0.2.1/zstd/source/zstd/compress.d(53,5): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.

```